### PR TITLE
Fix incorrect function call to getItemLifecycleState

### DIFF
--- a/src/components/qti/QtiAssessmentItem.vue
+++ b/src/components/qti/QtiAssessmentItem.vue
@@ -405,7 +405,7 @@ export default {
       if (!store.getItemContextSessionControl().getShowSolution()) return
 
       // NOOP if Item lifecycle is not 'solution'
-      if (store.getItemLifecycleState() !== 'solution') return
+      if (store.getItemLifecycleStatus() !== 'solution') return
 
       store.getInteractions().forEach((interaction) => {
         if (interaction.node.showSolution) {


### PR DESCRIPTION
Replaced a call to the non-existent getItemLifecycleState function with the correct getItemLifecycleStatus. 