### PR TITLE
Add keyboard reordering for order interaction

### DIFF
--- a/order-keyboard-test.html
+++ b/order-keyboard-test.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Order Keyboard Test</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/orderKeyboardTest.js"></script>
+  </body>
+</html>

--- a/src/OrderKeyboardTestApp.vue
+++ b/src/OrderKeyboardTestApp.vue
@@ -135,64 +135,20 @@ export default {
 <style>
 body {
   margin: 0;
-  background: #f5f7fb;
-  color: #1b2430;
-  font-family: "Avenir Next", Avenir, "Segoe UI", sans-serif;
 }
 
 .test-shell {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 2rem 1.25rem 3rem;
+  padding: 1rem;
 }
 
 .test-header {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  align-items: end;
-  justify-content: space-between;
   margin-bottom: 1.5rem;
-}
-
-.eyebrow {
-  margin: 0 0 0.35rem;
-  font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: #4d648d;
-}
-
-h1 {
-  margin: 0;
-  font-size: clamp(1.8rem, 4vw, 2.6rem);
-  line-height: 1.05;
-}
-
-.instructions {
-  max-width: 42rem;
-  margin: 0.75rem 0 0;
-  line-height: 1.5;
 }
 
 .sample-switcher {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
-}
-
-.sample-switcher button {
-  border: 1px solid #1b2430;
-  background: #fff;
-  color: #1b2430;
-  border-radius: 999px;
-  padding: 0.7rem 1rem;
-  font-weight: 600;
-}
-
-.sample-switcher button:hover {
-  background: #1b2430;
-  color: #fff;
+  margin-top: 0.75rem;
 }
 </style>

--- a/src/OrderKeyboardTestApp.vue
+++ b/src/OrderKeyboardTestApp.vue
@@ -1,0 +1,198 @@
+<template>
+  <main class="test-shell">
+    <header class="test-header">
+      <div>
+        <p class="eyebrow">Manual Verification</p>
+        <h1>Order Interaction Keyboard Test</h1>
+        <p class="instructions">
+          Tab into a choice, then use
+          <strong>{{ arrowInstructions }}</strong>
+          to move it. Press <strong>Home</strong> to send it to the start and
+          <strong>End</strong> to send it to the end.
+        </p>
+      </div>
+
+      <div class="sample-switcher">
+        <button type="button" @click="loadSample('horizontal')">
+          Horizontal Sample
+        </button>
+        <button type="button" @click="loadSample('vertical')">
+          Vertical Sample
+        </button>
+      </div>
+    </header>
+
+    <Qti3Player
+      ref="qti3player"
+      container-class="qti3-player-container-fluid"
+      color-class="qti3-player-color-default"
+      container-padding-class="qti3-player-container-padding-2"
+      suppress-alert-messages
+      suppress-invalid-response-messages
+      @notifyQti3PlayerReady="handlePlayerReady"
+    />
+  </main>
+</template>
+
+<script>
+import Qti3Player from '@/components/Qti3Player.vue'
+import { PnpFactory } from '@/shared/helpers/PnpFactory'
+import { SessionControlFactory } from '@/shared/helpers/SessionControlFactory'
+
+const SAMPLE_ITEMS = {
+  horizontal: {
+    guid: 'order-keyboard-horizontal-guid',
+    xml: `<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd" identifier="order-keyboard-horizontal" title="Order keyboard horizontal" adaptive="false" time-dependent="false">
+      <qti-response-declaration identifier="RESPONSE" cardinality="ordered" base-type="identifier"/>
+      <qti-item-body>
+        <qti-order-interaction response-identifier="RESPONSE" orientation="horizontal">
+          <qti-prompt>Put these presidents in chronological order by presidency.</qti-prompt>
+          <qti-simple-choice identifier="CHOICE_D">Theodore Roosevelt</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_A">James Madison</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_C">Abraham Lincoln</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_B">Andrew Jackson</qti-simple-choice>
+        </qti-order-interaction>
+      </qti-item-body>
+    </qti-assessment-item>`
+  },
+  vertical: {
+    guid: 'order-keyboard-vertical-guid',
+    xml: `<qti-assessment-item xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqtiasi_v3p0 https://purl.imsglobal.org/spec/qti/v3p0/schema/xsd/imsqti_asiv3p0_v1p0.xsd" identifier="order-keyboard-vertical" title="Order keyboard vertical" adaptive="false" time-dependent="false">
+      <qti-response-declaration identifier="RESPONSE" cardinality="ordered" base-type="identifier"/>
+      <qti-item-body>
+        <qti-order-interaction response-identifier="RESPONSE" orientation="vertical">
+          <qti-prompt>Put these presidents in chronological order by presidency.</qti-prompt>
+          <qti-simple-choice identifier="CHOICE_D">Theodore Roosevelt</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_A">James Madison</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_C">Abraham Lincoln</qti-simple-choice>
+          <qti-simple-choice identifier="CHOICE_B">Andrew Jackson</qti-simple-choice>
+        </qti-order-interaction>
+      </qti-item-body>
+    </qti-assessment-item>`
+  }
+}
+
+export default {
+  name: 'OrderKeyboardTestApp',
+
+  components: {
+    Qti3Player
+  },
+
+  data () {
+    return {
+      qti3Player: null,
+      pnp: null,
+      sessionControl: null,
+      currentSample: 'horizontal'
+    }
+  },
+
+  computed: {
+    arrowInstructions () {
+      return (this.currentSample === 'vertical')
+        ? 'Up and Down arrow keys'
+        : 'Left and Right arrow keys'
+    }
+  },
+
+  methods: {
+    initialize () {
+      this.pnp = new PnpFactory()
+      this.sessionControl = new SessionControlFactory()
+      this.sessionControl.setValidateResponses(false)
+      this.sessionControl.setShowFeedback(false)
+    },
+
+    getConfiguration (guid) {
+      return {
+        guid,
+        pnp: this.pnp.getPnp(),
+        sessionControl: this.sessionControl.getSessionControl()
+      }
+    },
+
+    loadSample (sampleKey) {
+      if (this.qti3Player === null) return
+
+      this.currentSample = sampleKey
+      const sample = SAMPLE_ITEMS[sampleKey]
+      this.qti3Player.loadItemFromXml(sample.xml, this.getConfiguration(sample.guid))
+    },
+
+    handlePlayerReady (qti3Player) {
+      this.qti3Player = qti3Player
+      this.loadSample(this.currentSample)
+    }
+  },
+
+  created () {
+    this.initialize()
+  }
+}
+</script>
+
+<style>
+body {
+  margin: 0;
+  background: #f5f7fb;
+  color: #1b2430;
+  font-family: "Avenir Next", Avenir, "Segoe UI", sans-serif;
+}
+
+.test-shell {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+.test-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: end;
+  justify-content: space-between;
+  margin-bottom: 1.5rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4d648d;
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.05;
+}
+
+.instructions {
+  max-width: 42rem;
+  margin: 0.75rem 0 0;
+  line-height: 1.5;
+}
+
+.sample-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.sample-switcher button {
+  border: 1px solid #1b2430;
+  background: #fff;
+  color: #1b2430;
+  border-radius: 999px;
+  padding: 0.7rem 1rem;
+  font-weight: 600;
+}
+
+.sample-switcher button:hover {
+  background: #1b2430;
+  color: #fff;
+}
+</style>

--- a/src/components/qti/interactions/QtiSimpleChoice.vue
+++ b/src/components/qti/interactions/QtiSimpleChoice.vue
@@ -102,6 +102,7 @@ export default {
 
     handleClick () {
       if (this.isDisabled) return
+      if (this.parentCardinality === 'ordered') return
 
       if (this.isRadio) {
         this.$parent.$emit('setChecked', { 'identifier': this.identifier, 'checked': 'true' })
@@ -115,6 +116,8 @@ export default {
     },
 
     handleKeydown (event) {
+      if (this.parentCardinality === 'ordered') return
+
       let flag = false
 
       switch (event.code) {

--- a/src/components/qti/interactions/widgets/OrderInteractionWidget.js
+++ b/src/components/qti/interactions/widgets/OrderInteractionWidget.js
@@ -1,4 +1,7 @@
 import Sortable from 'sortablejs'
+import QtiAttributeValidation from '@/components/qti/validation/QtiAttributeValidation'
+
+const qtiAttributeValidation = new QtiAttributeValidation()
 
 class OrderInteractionWidget {
 
@@ -152,7 +155,7 @@ class OrderInteractionWidget {
     if (description === null) {
       description = document.createElement('div')
       description.classList.add('qti-visually-hidden', 'qti-order-keyboard-help')
-      description.id = `order_keyboard_help_${Math.random().toString(36).slice(2, 9)}`
+      description.id = this.createDomId('order_keyboard_help')
       this.wrapper.appendChild(description)
     }
 
@@ -171,6 +174,10 @@ class OrderInteractionWidget {
     }
 
     return liveRegion
+  }
+
+  createDomId (prefix) {
+    return `${prefix}_${qtiAttributeValidation.randomString(5, 'a')}`
   }
 
   handleDefaultKeyDown (event) {

--- a/src/components/qti/interactions/widgets/OrderInteractionWidget.js
+++ b/src/components/qti/interactions/widgets/OrderInteractionWidget.js
@@ -24,6 +24,7 @@ class OrderInteractionWidget {
     this.handleTouchStart = this.handleTouchStart.bind(this)
     this.handleTouchMove = this.handleTouchMove.bind(this)
     this.handleTouchEnd = this.handleTouchEnd.bind(this)
+    this.handleDefaultKeyDown = this.handleDefaultKeyDown.bind(this)
     this.notifyUpdate = this.notifyUpdate.bind(this)
 
     if (this.options.interactionSubType === 'default') {
@@ -34,6 +35,8 @@ class OrderInteractionWidget {
         animation: 400,
         onEnd: this.notifyUpdate
       })
+
+      this.initializeDefaultKeyboardSupport()
 
       // NOTE: No need to restore a response for 'default' order
       // interactions because the source qti-simple-choice Elements
@@ -119,12 +122,154 @@ class OrderInteractionWidget {
     this.options.onSelectionsLimit()
   }
 
+  initializeDefaultKeyboardSupport () {
+    this.defaultKeyboardDescriptionId = this.getOrCreateKeyboardDescription()
+    this.liveRegion = this.getOrCreateLiveRegion()
+
+    this.getChoiceElements().forEach((choice) => {
+      choice.setAttribute('aria-describedby', this.defaultKeyboardDescriptionId)
+    })
+
+    this.sourcewrapper.addEventListener('keydown', this.handleDefaultKeyDown)
+  }
+
+  getChoiceElements () {
+    return Array.from(this.sourcewrapper.querySelectorAll('.qti-simple-choice'))
+  }
+
+  isVerticalOrientation () {
+    return this.sourcewrapper.classList.contains('qti-orientation-vertical')
+  }
+
+  getKeyboardMoveKeysText () {
+    return this.isVerticalOrientation()
+      ? 'Up and Down arrow keys'
+      : 'Left and Right arrow keys'
+  }
+
+  getOrCreateKeyboardDescription () {
+    let description = this.wrapper.querySelector('.qti-order-keyboard-help')
+    if (description === null) {
+      description = document.createElement('div')
+      description.classList.add('qti-visually-hidden', 'qti-order-keyboard-help')
+      description.id = `order_keyboard_help_${Math.random().toString(36).slice(2, 9)}`
+      this.wrapper.appendChild(description)
+    }
+
+    description.textContent = `Use ${this.getKeyboardMoveKeysText()} to move this item. Press Home to move it to the start or End to move it to the end.`
+    return description.id
+  }
+
+  getOrCreateLiveRegion () {
+    let liveRegion = this.wrapper.querySelector('.qti-order-live-region')
+    if (liveRegion === null) {
+      liveRegion = document.createElement('div')
+      liveRegion.classList.add('qti-visually-hidden', 'qti-order-live-region')
+      liveRegion.setAttribute('aria-live', 'polite')
+      liveRegion.setAttribute('aria-atomic', 'true')
+      this.wrapper.appendChild(liveRegion)
+    }
+
+    return liveRegion
+  }
+
+  handleDefaultKeyDown (event) {
+    if (this.isDisabled) return
+
+    const choice = this.getClosestElement(event.target, 'qti-simple-choice')
+    if (!choice) return
+
+    const action = this.getKeyboardAction(event.code)
+    if (action === null) return
+
+    event.preventDefault()
+    event.stopPropagation()
+
+    const choices = this.getChoiceElements()
+    const fromIndex = choices.indexOf(choice)
+    if (fromIndex < 0) return
+
+    let toIndex = fromIndex
+
+    switch (action) {
+      case 'previous':
+        toIndex -= 1
+        break
+      case 'next':
+        toIndex += 1
+        break
+      case 'first':
+        toIndex = 0
+        break
+      case 'last':
+        toIndex = choices.length - 1
+        break
+      default:
+        return
+    }
+
+    if ((toIndex < 0) || (toIndex >= choices.length) || (toIndex === fromIndex)) return
+
+    this.reorderChoice(choice, fromIndex, toIndex)
+    choice.focus()
+    this.announceKeyboardMove(choice, toIndex, choices.length)
+    this.notifyUpdate({ target: this.sourcewrapper })
+  }
+
+  getKeyboardAction (code) {
+    const isVertical = this.isVerticalOrientation()
+
+    switch (code) {
+      case 'ArrowUp':
+        return (isVertical ? 'previous' : null)
+      case 'ArrowDown':
+        return (isVertical ? 'next' : null)
+      case 'ArrowLeft':
+        return (isVertical ? null : 'previous')
+      case 'ArrowRight':
+        return (isVertical ? null : 'next')
+      case 'Home':
+        return 'first'
+      case 'End':
+        return 'last'
+      default:
+        return null
+    }
+  }
+
+  reorderChoice (choice, fromIndex, toIndex) {
+    const choices = this.getChoiceElements()
+    choices.splice(fromIndex, 1)
+    choices.splice(toIndex, 0, choice)
+    choices.forEach((node) => {
+      this.sourcewrapper.appendChild(node)
+    })
+  }
+
+  announceKeyboardMove (choice, toIndex, totalChoices) {
+    if (this.liveRegion === null) return
+
+    const description = choice.querySelector('.qti-choice-description')
+    const label = (description === null)
+      ? 'Item'
+      : description.textContent.trim()
+
+    this.liveRegion.textContent = ''
+    window.requestAnimationFrame(() => {
+      this.liveRegion.textContent = `${label} moved to position ${toIndex + 1} of ${totalChoices}.`
+    })
+  }
+
   toggleDisable (isDisabled) {
     this.isDisabled = isDisabled
 
     if ((this.options.interactionSubType === 'default') && (this.sortable !== null)) {
       // Disable sortable
       this.sortable.option('disabled', isDisabled)
+
+      this.getChoiceElements().forEach((choice) => {
+        choice.setAttribute('aria-disabled', `${isDisabled}`)
+      })
 
       // Update the class of all draggers
       const draggers = this.sourcewrapper.querySelectorAll('.draggable')
@@ -714,6 +859,8 @@ class OrderInteractionWidget {
   }
 
   destroy () {
+    this.sourcewrapper.removeEventListener('keydown', this.handleDefaultKeyDown)
+
     if (this.options.interactionSubType === 'ordermatch') {
 
       if (this.currentDragger !== null) {

--- a/src/components/qti/interactions/widgets/OrderInteractionWidget.js
+++ b/src/components/qti/interactions/widgets/OrderInteractionWidget.js
@@ -196,26 +196,8 @@ class OrderInteractionWidget {
     const fromIndex = choices.indexOf(choice)
     if (fromIndex < 0) return
 
-    let toIndex = fromIndex
-
-    switch (action) {
-      case 'previous':
-        toIndex -= 1
-        break
-      case 'next':
-        toIndex += 1
-        break
-      case 'first':
-        toIndex = 0
-        break
-      case 'last':
-        toIndex = choices.length - 1
-        break
-      default:
-        return
-    }
-
-    if ((toIndex < 0) || (toIndex >= choices.length) || (toIndex === fromIndex)) return
+    const toIndex = this.getTargetIndex(action, fromIndex, choices.length)
+    if ((toIndex === null) || (toIndex === fromIndex)) return
 
     this.reorderChoice(choice, fromIndex, toIndex)
     choice.focus()
@@ -239,6 +221,27 @@ class OrderInteractionWidget {
         return 'first'
       case 'End':
         return 'last'
+      default:
+        return null
+    }
+  }
+
+  getTargetIndex (action, fromIndex, choiceCount) {
+    const offsets = {
+      previous: -1,
+      next: 1
+    }
+
+    if (action in offsets) {
+      const toIndex = fromIndex + offsets[action]
+      return ((toIndex < 0) || (toIndex >= choiceCount)) ? null : toIndex
+    }
+
+    switch (action) {
+      case 'first':
+        return 0
+      case 'last':
+        return choiceCount - 1
       default:
         return null
     }

--- a/src/orderKeyboardTest.js
+++ b/src/orderKeyboardTest.js
@@ -1,0 +1,6 @@
+import { createApp } from 'vue'
+import OrderKeyboardTestApp from './OrderKeyboardTestApp.vue'
+
+createApp(OrderKeyboardTestApp)
+  .provide('$VUE_APP_CONTEXT', (window?.qti3PlayerContext || null))
+  .mount('#app')


### PR DESCRIPTION
Found while testing an ordering action. Drag-and-drop worked great with a mouse but didn't work with a keyboard. the idea is to grab the item with a space/enter and then to move it with arrows