### PR TITLE
Fix gap match target registration

### DIFF
--- a/src/components/qti/interactions/GapMatchGroup.vue
+++ b/src/components/qti/interactions/GapMatchGroup.vue
@@ -296,11 +296,10 @@ export default {
       // Insert the empty target wrapper immediately after the Choice Wrapper
       this.insertAfter(gapTargetWrapper, gapChoiceWrapperElement)
 
-      // The next element sibling after the target wrapper SHOULD BE the
-      // element containing all gaps.  Append the element to the target wrapper.
-      const gapContentElement = gapTargetWrapper.nextElementSibling
-      if (gapContentElement != null) {
-        gapTargetWrapper.append(gapContentElement)
+      // Move all remaining gap content into the target wrapper. Gap content can
+      // be split across sibling blocks, and every gap must be registered.
+      while (gapTargetWrapper.nextElementSibling != null) {
+        gapTargetWrapper.append(gapTargetWrapper.nextElementSibling)
       }
 
       // Return the wrapper


### PR DESCRIPTION
I think the issue is that this code assumes all the gaps live inside one sibling element.

That works for markup like:

```xml
<p>First <qti-gap identifier="GAP_1"/> and second <qti-gap identifier="GAP_2"/>.</p>
```

But it breaks when the gaps are split across separate blocks:

```html
<p>First <qti-gap identifier="GAP_1"/>.</p>
<p>Second <qti-gap identifier="GAP_2"/>.</p>
```

In that case, the old code only moves the first `<p>` into the target wrapper. So GAP_1 gets registered as a drop target, but GAP_2 stays outside the wrapper. It still shows up on screen, but the widget never sees it in `initializeTargets()`, so drops on GAP_2 get rejected.

My proposed fix is to move all remaining sibling content into the target wrapper, not just the first sibling:

```javascript
while (gapTargetWrapper.nextElementSibling != null) {
  gapTargetWrapper.append(gapTargetWrapper.nextElementSibling)
}
```

That keeps the existing behavior for single-block content...... and also handles valid gap-match items where the gaps are spread across multiple paragraphs.

```xml
<qti-assessment-item
  xmlns="http://www.imsglobal.org/xsd/imsqtiasi_v3p0"
  identifier="gap-match-multiple-blocks"
  title="Gap match with gaps in separate paragraphs"
  time-dependent="false"
  xml:lang="en-US">
  <qti-response-declaration identifier="RESPONSE" cardinality="multiple" base-type="directedPair">
    <qti-correct-response>
      <qti-value>A GAP_1</qti-value>
      <qti-value>B GAP_2</qti-value>
    </qti-correct-response>
  </qti-response-declaration>

  <qti-outcome-declaration identifier="SCORE" cardinality="single" base-type="float"/>

  <qti-item-body>
    <qti-gap-match-interaction response-identifier="RESPONSE" min-associations="2" max-associations="2">
      <qti-prompt>
        <p>Drag each choice into the correct blank.</p>
      </qti-prompt>

      <qti-gap-text identifier="A" match-max="1">George Washington</qti-gap-text>
      <qti-gap-text identifier="B" match-max="1">Abraham Lincoln</qti-gap-text>

      <p>The first President was <qti-gap identifier="GAP_1"/>.</p>
      <p>The President who issued the Emancipation Proclamation was <qti-gap identifier="GAP_2"/>.</p>
    </qti-gap-match-interaction>
  </qti-item-body>
</qti-assessment-item>
```